### PR TITLE
Implement simple in-memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Press _d_ for Docker when prompted or select it if a terminal UI appears.
 
 These requirements only apply if you use the non-Docker variant for installation, i. e. as a systemd service unit.
 
-- A Redis-compatible database (e. g. Valkey, KeyDB, Redis, ...; optional if caching is disabled)
+- A Redis-compatible database (e. g. Valkey, KeyDB, Redis, ...; optional)
 - Postfix
 - Go (latest)
 - DNSSEC-validating DNS server (preferably on localhost)
@@ -157,7 +157,7 @@ dns:
   address: 127.0.0.53:53
 
 redis:
-  # disable caching (default false)
+  # disable redis (will use in-memory cache)
   disable: false
 
   # Redis compatible server:port to act as a cache

--- a/configs/config.default.yaml
+++ b/configs/config.default.yaml
@@ -16,7 +16,7 @@ dns:
   address: 127.0.0.53:53
 
 redis:
-  # disable caching (default false)
+  # disable redis, will use in-memory database instead (default false)
   disable: false
 
   # Redis compatible server:port to act as a cache

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ * Copyright (c) 2025 Vincent Breitmoser
+ */
+
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	CACHE_NOTFOUND_TTL = 600
+	CACHE_MIN_TTL      = 180
+
+	VALKEY_DB_SCHEMA        = "3"
+	VALKEY_CACHE_KEY_PREFIX = "TLSPOL-"
+)
+
+type CacheStruct struct {
+	Domain string `json:"d"`
+	Result string `json:"r"`
+	Report string `json:"p"`
+	Ttl    uint32 `json:"t"`
+}
+
+type Cache interface {
+	Get(ctx context.Context, cacheKey string) (*CacheStruct, uint32, error)
+	Set(ctx context.Context, cacheKey string, data *CacheStruct, ttl time.Duration) error
+	Keys(ctx context.Context) ([]string, error)
+	UpdateDatabase(ctx context.Context) error
+	PurgeDatabase(ctx context.Context) error
+}

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ * Copyright (c) 2025 Vincent Breitmoser
+ */
+
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+type memoryEntry struct {
+	expiresAt time.Time
+	cs        *CacheStruct
+}
+
+type MemoryCache struct {
+	cache map[string]memoryEntry
+}
+
+func NewMemoryCache() *MemoryCache {
+	cache := make(map[string]memoryEntry)
+	return &MemoryCache{cache}
+}
+
+func (c MemoryCache) Get(ctx context.Context, cacheKey string) (*CacheStruct, uint32, error) {
+	data, ok := c.cache[cacheKey]
+	if !ok {
+		return nil, 0, nil
+	}
+
+	ttl := data.expiresAt.Sub(time.Now())
+	if ttl < 0 {
+		return nil, 0, nil
+	}
+
+	return data.cs, uint32(ttl.Seconds()), nil
+}
+
+func (c *MemoryCache) Set(ctx context.Context, cacheKey string, data *CacheStruct, ttl time.Duration) error {
+	c.cache[cacheKey] = memoryEntry{cs: data, expiresAt: time.Now().Add(ttl)}
+	return nil
+}
+
+func (c *MemoryCache) Keys(ctx context.Context) ([]string, error) {
+	keys := make([]string, len(c.cache))
+
+	i := 0
+	for k := range c.cache {
+		keys[i] = k
+		i++
+	}
+
+	return keys, nil
+}
+
+func (c *MemoryCache) PurgeDatabase(ctx context.Context) error {
+	clear(c.cache)
+	return nil
+}
+
+func (c *MemoryCache) UpdateDatabase(ctx context.Context) error {
+	// nothing to do here
+	return nil
+}

--- a/internal/cache/memory_test.go
+++ b/internal/cache/memory_test.go
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ * Copyright (c) 2025 Vincent Breitmoser
+ */
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	cache := NewMemoryCache()
+
+	entry := &CacheStruct{
+		Domain: "domain",
+		Result: "result",
+		Report: "report",
+		Ttl:    30,
+	}
+
+	err := cache.Set(ctx, "cacheKey", entry, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	got, ttl, err := cache.Get(ctx, "cacheKey")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ttl >= 20 {
+		t.Errorf("expected ttl to be less than what we put (20), got %d", ttl)
+	}
+	if got != entry {
+		t.Fatalf("expected entry to return same object %v, got %v", entry, got)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	got, _, err = cache.Get(ctx, "cacheKey")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != nil {
+		t.Errorf("nuexpected return value: %v", got)
+	}
+}

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ * Copyright (c) 2024-2025 Zuplu
+ */
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Zuplu/postfix-tlspol/internal/utils/log"
+	"github.com/valkey-io/valkey-go"
+	"github.com/valkey-io/valkey-go/valkeycompat"
+)
+
+type RedisCache struct {
+	dbAdapter valkeycompat.Cmdable
+}
+
+func NewRedisCache(address, password string, db int) *RedisCache {
+	// Setup redis client for cache
+	valkeyClient, err := valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{address},
+		Password:    password,
+		SelectDB:    db,
+	})
+	if err != nil {
+		log.Errorf("Could not initialize Valkey (Redis) client: %v", err)
+		return nil
+	}
+	dbAdapter := valkeycompat.NewAdapter(valkeyClient)
+	return &RedisCache{dbAdapter}
+}
+
+func (c RedisCache) Get(ctx context.Context, cacheKey string) (*CacheStruct, uint32, error) {
+	var data *CacheStruct
+
+	jsonData, err := c.dbAdapter.Cache(CACHE_MIN_TTL*time.Second).Get(ctx, VALKEY_CACHE_KEY_PREFIX+cacheKey).Result()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	ttl, err := c.dbAdapter.Cache(CACHE_MIN_TTL*time.Second).TTL(ctx, VALKEY_CACHE_KEY_PREFIX+cacheKey).Result()
+	if err != nil {
+		log.Warnf("Error getting TTL: %v", err)
+		return nil, 0, err
+	}
+
+	return data, uint32(ttl.Seconds()), json.Unmarshal([]byte(jsonData), data)
+}
+
+func (c *RedisCache) Set(ctx context.Context, cacheKey string, data *CacheStruct, ttl time.Duration) error {
+	jsonData, err := json.Marshal(*data)
+	if err != nil {
+		return fmt.Errorf("Error marshaling JSON: %v", err)
+	}
+
+	return c.dbAdapter.Set(ctx, VALKEY_CACHE_KEY_PREFIX+cacheKey, jsonData, ttl).Err()
+}
+
+func (c *RedisCache) Keys(ctx context.Context) ([]string, error) {
+	keys, err := c.dbAdapter.Keys(ctx, VALKEY_CACHE_KEY_PREFIX+"*").Result()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if k == VALKEY_CACHE_KEY_PREFIX+"version" {
+			continue
+		}
+
+		result = append(result, strings.TrimPrefix(k, VALKEY_CACHE_KEY_PREFIX))
+	}
+	return result, nil
+}
+
+func (c *RedisCache) PurgeDatabase(ctx context.Context) error {
+	keys, err := c.dbAdapter.Keys(ctx, VALKEY_CACHE_KEY_PREFIX+"*").Result()
+	if err != nil {
+		return fmt.Errorf("Error fetching keys: %v", err)
+	}
+	for _, key := range keys {
+		c.dbAdapter.Del(ctx, key).Err()
+	}
+	return c.dbAdapter.Set(ctx, VALKEY_CACHE_KEY_PREFIX+"schema", VALKEY_DB_SCHEMA, 0).Err()
+}
+
+func (c *RedisCache) UpdateDatabase(ctx context.Context) error {
+	currentSchema, err := c.dbAdapter.Get(ctx, VALKEY_CACHE_KEY_PREFIX+"schema").Result()
+	if err != nil && err != valkeycompat.Nil {
+		return fmt.Errorf("Error getting schema from Valkey (Redis): %v", err)
+	}
+
+	// Check if the schema matches, else clear the database
+	if currentSchema != VALKEY_DB_SCHEMA {
+		return c.PurgeDatabase(ctx)
+	}
+
+	return nil
+}

--- a/internal/prefetch.go
+++ b/internal/prefetch.go
@@ -52,7 +52,7 @@ func prefetchCachedPolicies() {
 				<-semaphore
 			}()
 			cachedPolicy, ttl, err := cacheClient.Get(bgCtx, key)
-			if err != nil || cachedPolicy.Result == "" {
+			if err != nil || cachedPolicy == nil || cachedPolicy.Result == "" {
 				return
 			}
 			// Check if the original TTL is greater than the margin and within the prefetching range


### PR DESCRIPTION
Hey there,

first off, thanks for your work on this! The postfix dane and mta-sts ecosystem is in a pretty sorry state, glad someone is stepping up to improve it :+1:

While I liked most of your design decisions, I felt like the dependency on redis for caching is overkill for most deployment scenarios. It also adds significant overhead (network roundtrips, json encoding/decoding, the server itself, and deployment complexity), compared to a simple in-memory cache that can be instantly accessed.

I built this branch with a simple in-memory cache. I added a layer to allow switching out caches, and tried to preserve the redis caching code exactly as it was as much as possible.

Configuration-wise, the memory cache is enabled simply if redis is set to false. This was convenient since the redis config is already its own key with only redis-specific config, and I imagine that running without a cache is mostly a debug mode of operation. There are other ways to do it, I just tried to be least intrusive here.

Please let me know if you're interested in merging this, and if yes if you need any adaptions.