### PR TITLE
feat: fallback to system resolver without dns.address

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ server:
   cache-file: /var/lib/postfix-tlspol/cache.db
 
 dns:
-  # must support DNSSEC
-  address: 127.0.0.53:53
+  # must support DNSSEC, uses /etc/resolv.conf if unset
+  #address: 127.0.0.53:53
 ```
 
 # Prefetching

--- a/configs/config.default.yaml
+++ b/configs/config.default.yaml
@@ -16,5 +16,5 @@ server:
   cache-file: /var/lib/postfix-tlspol/cache.db
 
 dns:
-  # must support DNSSEC
-  address: 127.0.0.53:53
+  # must support DNSSEC, uses /etc/resolv.conf if unset
+  #address: 127.0.0.53:53

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -31,6 +31,7 @@ RUN mkdir -p /data \
 
 # Setup postfix-tlspol
 RUN sed -i -e "s/127\.0\.0\.1:8642/0\.0\.0\.0:8642/" \
+  -e "s/#address:/address:/" \
   -e "s/127\.0\.0\.53:53/127\.0\.0\.1:8053/" \
   -e "s!: /var/lib/postfix-tlspol/!: !" \
   /etc/postfix-tlspol/config.yaml \

--- a/internal/dane.go
+++ b/internal/dane.go
@@ -28,7 +28,11 @@ func getMxRecords(ctx *context.Context, domain *string) ([]string, uint32, error
 	m.SetQuestion(dns.Fqdn(*domain), dns.TypeMX)
 	m.SetEdns0(4096, true)
 
-	r, _, err := client.ExchangeContext(*ctx, m, config.Dns.Address)
+	resolverAddress, err := config.Dns.GetResolverAddress()
+	if err != nil {
+		return nil, 0, err, false
+	}
+	r, _, err := client.ExchangeContext(*ctx, m, resolverAddress)
 	if err != nil {
 		return nil, 0, err, false
 	}
@@ -77,7 +81,11 @@ ipCheck:
 		m.SetQuestion(dns.Fqdn(*mx), t)
 		m.SetEdns0(4096, true)
 
-		r, _, err := client.ExchangeContext(*ctx, m, config.Dns.Address)
+		resolverAddress, err := config.Dns.GetResolverAddress()
+		if err != nil {
+			return MxFail
+		}
+		r, _, err := client.ExchangeContext(*ctx, m, resolverAddress)
 		if err != nil {
 			return MxFail
 		}
@@ -135,7 +143,11 @@ func checkTlsa(ctx *context.Context, mx *string) ResultWithTTL {
 	m.SetQuestion(dns.Fqdn("_25._tcp."+*mx), dns.TypeTLSA)
 	m.SetEdns0(4096, true)
 
-	r, _, err := client.ExchangeContext(*ctx, m, config.Dns.Address)
+	resolverAddress, err := config.Dns.GetResolverAddress()
+	if err != nil {
+		return ResultWithTTL{Result: "", TTL: 0, Err: err}
+	}
+	r, _, err := client.ExchangeContext(*ctx, m, resolverAddress)
 	if err != nil {
 		return ResultWithTTL{Result: "", TTL: 0, Err: err}
 	}

--- a/internal/dane_test.go
+++ b/internal/dane_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 func init() {
+	address := "8.8.8.8:53"
 	config = Config{
 		Server: ServerConfig{},
 		Dns: DnsConfig{
-			Address: "8.8.8.8:53",
+			Address: &address,
 		},
 	}
 }

--- a/internal/mta-sts.go
+++ b/internal/mta-sts.go
@@ -26,7 +26,11 @@ func checkMtaStsRecord(ctx *context.Context, domain *string) (bool, error) {
 	m.SetQuestion(dns.Fqdn("_mta-sts."+*domain), dns.TypeTXT)
 	m.SetEdns0(4096, false)
 
-	r, _, err := client.ExchangeContext(*ctx, m, config.Dns.Address)
+	resolverAddress, err := config.Dns.GetResolverAddress()
+	if err != nil {
+		return false, err
+	}
+	r, _, err := client.ExchangeContext(*ctx, m, resolverAddress)
 	if err != nil {
 		return false, err
 	}

--- a/internal/mta-sts_test.go
+++ b/internal/mta-sts_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func init() {
+	address := "8.8.8.8:53"
 	config = Config{
 		Server: ServerConfig{},
 		Dns: DnsConfig{
-			Address: "8.8.8.8:53",
+			Address: &address,
 		},
 	}
 }

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 func init() {
+	address := "8.8.8.8:53"
 	config = Config{
 		Server: ServerConfig{},
 		Dns: DnsConfig{
-			Address: "8.8.8.8:53",
+			Address: &address,
 		},
 	}
 }


### PR DESCRIPTION
This implements proposal #59. WDYT?

This makes `dns.address` a pointer, so it can be `nil` by default, if unset.